### PR TITLE
Update ffmpeg.md

### DIFF
--- a/docs/zh-CN/guide/ffmpeg.md
+++ b/docs/zh-CN/guide/ffmpeg.md
@@ -14,7 +14,7 @@
 
 ### Windows 系统
 
-1. 在 [此处](https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-2024-02-15-git-a2cfd6062c-full_build.7z) 下载官方许可的 FFmpeg；
+1. 在 [此处](https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-7.0-full_build.7z) 下载官方许可的 FFmpeg；
 2. 将其中的文件夹解压至一个你知道的地方（例如 `C:\Program Files`），然后重命名为 `ffmpeg`；
 3. 你的 `ffmpeg` 文件夹的结构看起来应该是这样的：
     ```


### PR DESCRIPTION
Change the download link of ffmpeg in line 17
use the download link of ffmpeg v7.0 from https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-7.0-full_build.7z to take the place of  **the old and unavailable** link  
更改17行中ffmpeg的下载链接
使用来自https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-7.0-full_build.7z 的ffmpeg  v7.0下载链接替代**旧且已经不可用**的链接