### PR TITLE
doc: change the python version in the doc

### DIFF
--- a/docs/zh-CN/guide/nonebot2.md
+++ b/docs/zh-CN/guide/nonebot2.md
@@ -4,7 +4,7 @@
 
 ## 1. 环境
 
-​**Python 版本 >= 3.10**
+​**Python 版本 >= 3.9**
 
 [Python 官网](https://www.python.org/)，如果有小白打不开或者找不到下载位置，这里提供一个 [Python 3.9.10](https://syykln.lanzoul.com/iZegc1rwtm1i)。
 


### PR DESCRIPTION
-  `nonebot-plugin-llob-master`没有用到 Python3.10 一些特性，所以应该也能和`Nonebot2`一样在 Python3.9+ 版本运行，已在`nonebot-plugin-llob-master`插件 README.md 中修正。<br>

-  并且文档要求 Python>=3.10 ，但提供了 Python3.9 下载，有点怪（草）
