### PR TITLE
Update nonebot2.md

### DIFF
--- a/docs/zh-CN/guide/nonebot2.md
+++ b/docs/zh-CN/guide/nonebot2.md
@@ -132,6 +132,12 @@ COMMAND_SEP=["."]  # 配置命令分割字符
 }
 ```
 
+
+注：使用[Linux 一键 Docker 安装方案](https://llonebot.com/zh-CN/guide/getting-started#linux-%E4%B8%80%E9%94%AE-docker-%E5%AE%89%E8%A3%85%E6%96%B9%E6%A1%88)时需对脚本运行目录下 docker-compose.yml 配置文件进行以下修改
+```
+- ONEBOT_WS_URLS=["ws://172.17.0.1:8080/onebot/v11/ws"]
+```
+
 ​	显示一个bot QQ 链接说明成功！
 
 **到此完成！鼓掌祝贺**


### PR DESCRIPTION
更新docker一键安装后 连接NoneBot 的配置方法。

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

文档：
- 添加了修改 `docker-compose.yml` 的说明，通过将 `ONEBOT_WS_URLS` 设置为容器的 WebSocket 端点，以用于 Linux 一键 Docker 安装。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add instructions to modify docker-compose.yml by setting ONEBOT_WS_URLS to the container’s WebSocket endpoint for Linux one-click Docker installs

</details>