### PR TITLE
Update faq.md

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -9,7 +9,7 @@
 :::
 
 ::: details 忘记了 WebUI 密码
-密码位于 `data/webui_token.txt`
+密码位于 `./bin/llbot/data/webui_token.txt`
 ::: 
 
 ::: details 发送不了图片和语音


### PR DESCRIPTION
webui_token.txt 文件 位于  `./bin/llbot/data/webui_token.txt` 路径下

## 由 Sourcery 提供的摘要

文档：
- 更新“忘记 WebUI 密码”的常见问题条目，以引用正确的 `webui_token.txt` 文件路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the FAQ entry for forgotten WebUI passwords to reference the correct webui_token.txt file path.

</details>