### PR TITLE
fix(astrbot): 修复 AstrBot 下载源码安装包链接

### DIFF
--- a/content/docs/install_astrbot.mdx
+++ b/content/docs/install_astrbot.mdx
@@ -39,7 +39,7 @@ git clone https://github.com/AstrBotDevs/AstrBot.git
 cd AstrBot
 ```
 
-或者直接下载 ZIP：https://github.com/AstrBotDevs/AstrBot/archive/refs/heads/master.zip，解压后进入目录。
+或者直接下载 ZIP：https://github.com/AstrBotDevs/AstrBot/archive/refs/heads/master.zip ，解压后进入目录。
 </Step>
 
 <Step>


### PR DESCRIPTION
<img width="920" height="235" alt="image" src="https://github.com/user-attachments/assets/e060c0d3-318b-4d36-928a-19442cab76e0" />


<img width="1874" height="956" alt="image" src="https://github.com/user-attachments/assets/ccdf3b9f-5049-4fab-8df1-a03090656a0d" />

## Summary by Sourcery

Documentation:
- 更新 AstrBot 安装指南，修复源码包 ZIP 下载 URL 周围的空格问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the AstrBot installation guide to fix spacing around the ZIP download URL for the source package.

</details>