### PR TITLE
fix: 更新linux cli安装解压并进入目录的说明

### DIFF
--- a/components/installation-methods.tsx
+++ b/components/installation-methods.tsx
@@ -237,8 +237,8 @@ const methodsByOS: Record<OSKey, Method[]> = {
         },
         {
           title: '解压并进入目录',
-          detail: '解压后进入目录。',
-          code: 'unzip LLBot-CLI-linux-*.zip\ncd LLBot-CLI-linux-*',
+          detail: '先创建目录，再将压缩包解压到该目录后进入。',
+          code: 'mkdir LLBot-CLI-linux\nunzip LLBot-CLI-linux-*.zip -d LLBot-CLI-linux\ncd LLBot-CLI-linux',
         },
         {
           title: '启动',


### PR DESCRIPTION
<img width="1203" height="207" alt="image" src="https://github.com/user-attachments/assets/92d4d4da-26b5-4a1e-9021-9dc36cee027b" />

<img width="1170" height="261" alt="image" src="https://github.com/user-attachments/assets/f5def425-def9-4d59-b64f-0760960bc8e3" />

当前 Linux 步骤默认压缩包内自带顶层目录，但实际包内容是直接散落在根目录，如果不添加 -d 参数会解压到当前目录中

调整了相关命令和描述

<img width="1242" height="267" alt="image" src="https://github.com/user-attachments/assets/a667d1b4-2c68-429f-8220-d37c7680ad8f" />

## Summary by Sourcery

Documentation:
- 明确 Linux CLI 解压说明：先创建一个目录，将压缩包解压到该目录中，然后再切换到该目录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Clarify Linux CLI extraction instructions to create a directory and unzip the archive into it before changing directories.

</details>